### PR TITLE
Add set of rules to deprecate require.js and use ES6 syntax instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,24 @@
 
 module.exports = {
     rules: {
-        'conditional-async-require-forbidden': require('./lib/rules/conditional-async-require-forbidden')
+        'conditional-async-require-forbidden': require('./lib/rules/conditional-async-require-forbidden'),
+        'deprecate-define': require('./lib/rules/deprecate-define'),
+        'deprecate-sugar': require('./lib/rules/deprecate-sugar'),
+        'deprecate-strict': require('./lib/rules/deprecate-strict'),
+        'deprecate-globals': require('./lib/rules/deprecate-globals')
     },
     configs: {
         recommended: {
             rules: {
                 '@silesia-corporation/requirejs/conditional-async-require-forbidden': 1
+            }
+        },
+        deprecate: {
+            rules: {
+                '@silesia-corporation/requirejs/deprecate-define': 2,
+                '@silesia-corporation/requirejs/deprecate-sugar': 2,
+                '@silesia-corporation/requirejs/deprecate-strict': 2,
+                '@silesia-corporation/requirejs/deprecate-globals': 2
             }
         }
     }

--- a/lib/rules/deprecate-define.js
+++ b/lib/rules/deprecate-define.js
@@ -1,0 +1,92 @@
+"use strict";
+
+var _ = require("underscore");
+
+module.exports = {
+    meta: {
+        docs: {},
+        fixable: "code"
+    },
+    create: function (context) {
+        return {
+            "CallExpression": function (node) {
+                var hasDefine = node.callee.name === "define",
+                    hasDefineWithFunction =
+                        hasDefine &&
+                        node.arguments.length === 1 &&
+                        node.arguments[0].type === "FunctionExpression",
+                    hasDefineWithArrayDependencies = 
+                        hasDefine &&
+                        node.arguments.length === 2 &&
+                        node.arguments[1].type === "FunctionExpression",
+                    hasDefineWithObject = 
+                        hasDefine &&
+                        node.arguments.length === 1 &&
+                        node.arguments[0].type === "ObjectExpression",
+                    source,
+                    fix;
+
+                if (!hasDefine) return true;
+
+                if (hasDefineWithFunction) {
+                    fix = function (fixer) {
+                        var source = context.getSourceCode().getText(node.arguments[0].body),
+                            returnStatement = _.findWhere(node.arguments[0].body.body, {type: "ReturnStatement"}),
+                            returnStatementSource,
+                            exportDefaultStatementSource;
+
+                        if (returnStatement) {
+                            returnStatementSource = context.getSourceCode().getText(returnStatement),
+                            exportDefaultStatementSource = returnStatementSource.replace("return", "export default");
+                            source = source.replace(returnStatementSource, exportDefaultStatementSource);
+                        }
+
+                        return fixer.replaceText(node, source.slice(1, -1));
+                    }
+                }
+
+                if (hasDefineWithArrayDependencies) {
+                    fix = function (fixer) {
+                        var source = context.getSourceCode().getText(node.arguments[1].body),
+                            params = node.arguments[1].params,
+                            dependencies = node.arguments[0].elements,
+                            head = "",
+                            returnStatement = _.findWhere(node.arguments[1].body.body, {type: "ReturnStatement"}),
+                            returnStatementSource,
+                            exportDefaultStatementSource;
+
+                        if (returnStatement) {
+                            returnStatementSource = context.getSourceCode().getText(returnStatement),
+                            exportDefaultStatementSource = returnStatementSource.replace("return", "export default");
+                            source = source.replace(returnStatementSource, exportDefaultStatementSource);
+                        }
+
+                        if (!_.isEmpty(dependencies)) {
+                            _.each(dependencies, function (dependency, idx) {
+                                if (params[idx]) head += "import " + params[idx].name + " from \"" + dependency.value +"\";\r\n"
+                                else head += "import \"" + dependency.value + "\";\r\n";
+                            });
+                            head += "\r\n"
+                        }
+
+                        return fixer.replaceText(node, head + source.slice(1, -1));
+                    }
+                }
+
+                if (hasDefineWithObject) {
+                    fix = function (fixer) {
+                        var source = context.getSourceCode().getText(node.arguments[0]);
+                        return fixer.replaceText(node, "export default " + source);
+                    }
+                }
+
+                context.report({
+                    node: node,
+                    message: "Deprecated require.js `define` statement. Use `export` and `import` instead.",
+                    fix: fix
+                });
+            }
+        };
+    }
+
+};

--- a/lib/rules/deprecate-globals.js
+++ b/lib/rules/deprecate-globals.js
@@ -1,0 +1,38 @@
+"use strict";
+
+var _ = require("underscore");
+
+module.exports = {
+    meta: {
+        docs: {},
+        fixable: "code"
+    },
+    create: function (context) {
+        return {
+            "Program": function (node) {
+                var comments = node.comments,
+                    unnecessary = ["define", "require"],
+                    firstComment = comments && comments[0],
+                    firstCommentValue = (firstComment && firstComment.value.trim()) || "",
+                    isFirstCommentGlobals = firstCommentValue.indexOf("globals") === 0,
+                    before = firstCommentValue.replace("globals ", "").split(", "),
+                    after = before.filter(function (variable) { return unnecessary.indexOf(variable) < 0; });
+
+                if (before.length === after.length) return true;
+
+                context.report({
+                    node: comments && comments[0],
+                    message: "Deprecated variables `require` and `define` in globals, remove them.",
+                    fix: function (fixer) {
+                        var newGlobals = after.length > 0 && "/*globals " + after.join(", ") + "*/\r\n\r\n",
+                            globalsRange = [firstComment.start, firstComment.end];
+
+                        if (newGlobals) return fixer.replaceTextRange(globalsRange, newGlobals);
+                        else return fixer.removeRange(globalsRange);
+                    }
+                });
+            }
+        };
+    }
+
+};

--- a/lib/rules/deprecate-strict.js
+++ b/lib/rules/deprecate-strict.js
@@ -1,0 +1,32 @@
+"use strict";
+
+var _ = require("underscore");
+
+module.exports = {
+    meta: {
+        docs: {},
+        fixable: "code"
+    },
+    create: function (context) {
+        return {
+            "Program": function (node) {
+                var useStrictNode = _.find(node.body, function (statement) {
+                    return statement.type === "ExpressionStatement" &&
+                        statement.expression.type === "Literal" &&
+                        statement.expression.value === "use strict";
+                });
+
+                if (!useStrictNode) return;
+
+                context.report({
+                    node: node,
+                    message: "Deprecated `use strict` statement, remove it.",
+                    fix: function (fixer) {
+                        return fixer.remove(useStrictNode);
+                    }
+                });
+            }
+        };
+    }
+
+};

--- a/lib/rules/deprecate-sugar.js
+++ b/lib/rules/deprecate-sugar.js
@@ -1,0 +1,71 @@
+"use strict";
+
+var _ = require("underscore");
+
+module.exports = {
+    meta: {
+        docs: {},
+        fixable: "code"
+    },
+    create: function (context) {
+        return {
+            "Program": function (node) {
+                var allVars = _.findWhere(node.body, {type: "VariableDeclaration"}) || {},
+                    requireVars = [],
+                    nonRequireVars = [],
+                    requireStatements = _.filter(node.body, function (statement) {
+                        return statement.type === "ExpressionStatement" &&
+                            statement.expression &&
+                            statement.expression.callee &&
+                            statement.expression.callee.name === "require";
+                    }) || [];
+
+                if (!allVars && !requireStatements) return true;
+
+                _.each(allVars.declarations, function (variable) {
+                    var isRequire = variable.init &&
+						variable.init.type === "CallExpression" &&
+                        variable.init.callee &&
+                        variable.init.callee.name === "require";
+                    if (isRequire) requireVars.push(variable);
+                    else nonRequireVars.push(context.getSourceCode().getText(variable));
+                });
+
+                if (requireVars.length === 0 && requireStatements.length === 0) return true;
+                
+                context.report({
+                    node: node,
+                    message: "Deprecated require sugar syntax, use import instead.",
+                    fix: function (fixer) {
+                        var head = "",
+                            fixers = [];
+
+                        _.each(requireVars, function (requireDeclaration) {
+                            var name = requireDeclaration.id.name,
+                                value = requireDeclaration.init.arguments[0].value;
+
+                            head += "import " + name + " from \"" + value + "\";\r\n";
+                        });
+
+                        _.each(requireStatements, function (requireStatement) {
+                            var value = requireStatement.expression.arguments[0].value;
+                            head += "import \"" + value + "\";\r\n";
+                        });
+
+                        if (nonRequireVars.length > 0)
+                            head += "\r\nvar " + nonRequireVars.join(",\r\n") + ";";
+
+                        fixers.push(fixer.insertTextAfterRange([0, 0], head));
+                        if (!_.isEmpty(allVars)) fixers.push(fixer.remove(allVars));
+                        _.each(requireStatements, function (requireStatement) {
+                            fixers.push(fixer.remove(requireStatement));
+                        });
+
+                        return fixers;
+                    }
+                });
+            }
+        };
+    }
+
+};

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@silesia-corporation/eslint-plugin-requirejs",
   "description": "ESLint rules for requirejs",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "devDependencies": {
     "ava": "0.19.1",
+    "eslint": "4.2.0",
     "eslint-ava-rule-tester": "2.0.2",
     "nyc": "10.2.0"
   },
@@ -17,5 +18,8 @@
     "eslint-plugin",
     "eslintplugin",
     "requirejs"
-  ]
+  ],
+  "dependencies": {
+    "underscore": "^1.8.3"
+  }
 }

--- a/test/rules/deprecate-define.js
+++ b/test/rules/deprecate-define.js
@@ -1,0 +1,87 @@
+import test from 'ava';
+import rule from '../../lib/rules/deprecate-define';
+import AvaRuleTester from 'eslint-ava-rule-tester';
+
+const ruleTester = new AvaRuleTester(test, {
+    env: {
+        es6: true
+    }
+});
+
+test("rule is defined", t => {
+    t.truthy(rule);
+});
+
+ruleTester.run('deprecate-define', rule, {
+    valid: [
+        'function foo() {}',
+        'function foo() {var bar = require("bar");}',
+        'function foo() {require("bar", function () {});}',
+    ],
+    invalid: [
+        // define without dependencies in array
+        {
+            code: 'define(function () {})',
+            output: '',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+        {
+            code: 'define(function () {var bar = require("bar");})',
+            output: 'var bar = require("bar");',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+        {
+            code: 'define(function () {return {foo: "foo"}})',
+            output: 'export default {foo: "foo"}',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+        {
+            code: 'define(function () {var bar = require("bar");return {foo: "foo"}})',
+            output: 'var bar = require("bar");export default {foo: "foo"}',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+
+        // define with dependencies in array
+        {
+            code: 'define([], function () {})',
+            output: '',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+        {
+            code: 'define([], function () {return {foo: "foo"}})',
+            output: 'export default {foo: "foo"}',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+        {
+            code: 'define(["bar"], function () {})',
+            output:
+                'import "bar";\r\n' + 
+                '\r\n',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+        {
+            code: 'define(["baz"], function (baz) {})',
+            output:
+                'import baz from "baz";\r\n' + 
+                '\r\n',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+        {
+            code: 'define(["baz", "bar"], function (baz) {return {foo: "foo"}})',
+            output: 
+                'import baz from "baz";\r\n' + 
+                'import "bar";\r\n' + 
+                '\r\n' +
+                'export default {foo: "foo"}',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        },
+
+        // define with object
+        {
+            code: 'define({foo: "foo"})',
+            output: 'export default {foo: "foo"}',
+            errors: [{ message: 'Deprecated require.js `define` statement. Use `export` and `import` instead.' }]
+        }
+    ]
+});
+

--- a/test/rules/deprecate-globals.js
+++ b/test/rules/deprecate-globals.js
@@ -1,0 +1,48 @@
+import test from 'ava';
+import rule from '../../lib/rules/deprecate-globals';
+import AvaRuleTester from 'eslint-ava-rule-tester';
+
+const ruleTester = new AvaRuleTester(test, {
+    env: {
+        es6: true
+    }
+});
+
+test("rule is defined", t => {
+    t.truthy(rule);
+});
+
+ruleTester.run('deprecate-globals', rule, {
+    valid: [
+        '/*globals foo*/',
+        '/*another comment globals*/',
+        '/*another comment*//*globals foo*/',
+        'function foo () {}'
+    ],
+    invalid: [
+        {
+            code: '/*globals define*/',
+            output: '',
+            errors: [{ message: 'Deprecated variables `require` and `define` in globals, remove them.' }]
+        },
+        {
+            code: '/*globals require*/function foo () {}',
+            output: 'function foo () {}',
+            errors: [{ message: 'Deprecated variables `require` and `define` in globals, remove them.' }]
+        },
+        {
+            code: '/*globals define, require*//*another comment*/function foo () {}',
+            output: '/*another comment*/function foo () {}',
+            errors: [{ message: 'Deprecated variables `require` and `define` in globals, remove them.' }]
+        },
+        {
+            code: '/*globals define, require, foo*/function foo () {}',
+            output:
+                '/*globals foo*/\r\n' + 
+                '\r\n' + 
+                'function foo () {}',
+            errors: [{ message: 'Deprecated variables `require` and `define` in globals, remove them.' }]
+        }
+    ]
+});
+

--- a/test/rules/deprecate-strict.js
+++ b/test/rules/deprecate-strict.js
@@ -1,0 +1,27 @@
+import test from 'ava';
+import rule from '../../lib/rules/deprecate-strict';
+import AvaRuleTester from 'eslint-ava-rule-tester';
+
+const ruleTester = new AvaRuleTester(test, {
+    env: {
+        es6: true
+    }
+});
+
+test("rule is defined", t => {
+    t.truthy(rule);
+});
+
+ruleTester.run('deprecate-strict', rule, {
+    valid: [
+        'function foo () {}'
+    ],
+    invalid: [
+        {
+            code: '\'use strict\';function foo () {}',
+            output: 'function foo () {}',
+            errors: [{ message: 'Deprecated `use strict` statement, remove it.' }]
+        }
+    ]
+});
+

--- a/test/rules/deprecate-sugar.js
+++ b/test/rules/deprecate-sugar.js
@@ -1,0 +1,41 @@
+import test from 'ava';
+import rule from '../../lib/rules/deprecate-sugar';
+import AvaRuleTester from 'eslint-ava-rule-tester';
+
+const ruleTester = new AvaRuleTester(test, {
+    env: {
+        es6: true
+    }
+});
+
+test("rule is defined", t => {
+    t.truthy(rule);
+});
+
+ruleTester.run('deprecate-sugar', rule, {
+    valid: [
+        'function foo () { var bar = require("bar"); }'
+    ],
+    invalid: [
+        {
+            code: 'var foo = require("foo");',
+            output: 'import foo from "foo";\r\n',
+            errors: [{ message: 'Deprecated require sugar syntax, use import instead.' }]
+        },
+        {
+            code: 'require("bar");',
+            output: 'import "bar";\r\n',
+            errors: [{ message: 'Deprecated require sugar syntax, use import instead.' }]
+        },
+        {
+            code: 'var foo = require("foo"), baz = {};require("bar");',
+            output:
+                'import foo from "foo";\r\n' + 
+                'import "bar";\r\n' +
+                '\r\n' +
+                'var baz = {};',
+            errors: [{ message: 'Deprecated require sugar syntax, use import instead.' }]
+        },
+    ]
+});
+


### PR DESCRIPTION
Jest jeden problem z testatmi, zależność `eslint-ava-rule-tester` zaciąga eslinta w starej wersji w której nie jest wspierana jedna z używanych przeze mnie funkcjonalności. Żeby testy przeszły trzeba usunąć node_modules/eslint-ava-rule-tester/node_modules. Wtedy ładowany jest eslint z katalogu głównego i wszystko śmiga.